### PR TITLE
⚡ Avoid redundant filepath.Ext calls in RenameFiles

### DIFF
--- a/shared.go
+++ b/shared.go
@@ -42,11 +42,12 @@ func RenameFiles(files []string, renameFunc func(string) (string, error), dryRun
 		base := filepath.Base(file)
 
 		// Generate the new filename
-		baseNameRenamed, err := renameFunc(strings.TrimSuffix(base, filepath.Ext(base)))
+		ext := filepath.Ext(base)
+		baseNameRenamed, err := renameFunc(strings.TrimSuffix(base, ext))
 		if err != nil {
 			return err
 		}
-		newName := baseNameRenamed + filepath.Ext(base)
+		newName := baseNameRenamed + ext
 		newPath := filepath.Join(dir, newName)
 
 		// Skip if no changes


### PR DESCRIPTION
💡 **What:** Assigned the result of `filepath.Ext(base)` to a variable `ext` and reused it in `shared.go`.
🎯 **Why:** To avoid calling `filepath.Ext` twice for the same file, reducing CPU cycles.
📊 **Measured Improvement:**
Micro-benchmark of the logic showed a reduction from ~79.47 ns/op to ~68.24 ns/op (approx 14% improvement in the isolated logic block).
While the overall `RenameFiles` function is dominated by I/O, this micro-optimization makes the string manipulation part more efficient.

```
BenchmarkFileExtLogic/Current-4         	14843080	        79.47 ns/op
BenchmarkFileExtLogic/Optimized-4       	17071306	        68.24 ns/op
```

---
*PR created automatically by Jules for task [15578483692492362115](https://jules.google.com/task/15578483692492362115) started by @arran4*